### PR TITLE
feat: add option to only detect browser locale on root path

### DIFF
--- a/docs/browser-language-detection.md
+++ b/docs/browser-language-detection.md
@@ -9,14 +9,17 @@ By default, **nuxt-i18n** attempts to redirect users to their preferred language
   // ...
   detectBrowserLanguage: {
     useCookie: true,
-    cookieKey: 'i18n_redirected'
+    cookieKey: 'i18n_redirected',
+    // detectOnlyOnRoot: true,
   }
 }]
 ```
 
 ::: tip
-Browser language is detected either from `navigator` when running on client side, or from the `accept-language` HTTP header. Configured `locales` (or locales `code`s when locales are specified in object form) are matched against locales reported by the browser (for example `en-US,en;q=0.9,no;q=0.8`). If there is no exact match, the language code (letters before `-`) are matched against configured locales (for backwards compatibility).
+For better SEO, it's recommended to set `detectOnlyOnRoot` to `true`. With it set, the language detection is only attempted when the user visits the root path (`/`) of the site. This allows crawlers to access the requested page rather than being redirected away based on detected locale. It also allows linking to pages in specific locales.
 :::
+
+Browser language is detected either from `navigator` when running on client-side, or from the `accept-language` HTTP header. Configured `locales` (or locales `code`s when locales are specified in object form) are matched against locales reported by the browser (for example `en-US,en;q=0.9,no;q=0.8`). If there is no exact match for the full locale, the language code (letters before `-`) are matched against configured locales (for backward-compatibility).
 
 To prevent redirecting users every time they visit the app, **nuxt-i18n** sets a cookie after the first redirection. You can change the cookie's name by setting `detectBrowserLanguage.cookieKey` option to whatever you'd like, the default is _i18n_redirected_.
 

--- a/docs/es/browser-language-detection.md
+++ b/docs/es/browser-language-detection.md
@@ -2,17 +2,24 @@
 
 Por defecto, **nuxt-i18n** intenta redirigir a los usuarios a su idioma preferido al detectar el idioma de su navegador.  Esto está controlado por la opción  `detectBrowserLanguage`:
 
-
 ```js
 // nuxt.config.js
 
 ['nuxt-i18n', {
+  // ...
   detectBrowserLanguage: {
     useCookie: true,
-    cookieKey: 'i18n_redirected'
+    cookieKey: 'i18n_redirected',
+    // detectOnlyOnRoot: true,
   }
 }]
 ```
+
+::: tip
+For better SEO, it's recommended to set `detectOnlyOnRoot` to `true`. With it set, the language detection is only attempted when the user visits the root path (`/`) of the site. This allows crawlers to access the requested page rather than being redirected away based on detected locale. It also allows linking to pages in specific locales.
+:::
+
+Browser language is detected either from `navigator` when running on client-side, or from the `accept-language` HTTP header. Configured `locales` (or locales `code`s when locales are specified in object form) are matched against locales reported by the browser (for example `en-US,en;q=0.9,no;q=0.8`). If there is no exact match for the full locale, the language code (letters before `-`) are matched against configured locales (for backward-compatibility).
 
 Para evitar redirigir a los usuarios cada vez que visitan la aplicación, **nuxt-i18n** establece una cookie después de la primera redirección. Puede cambiar el nombre de la cookie configurando la opción `detectBrowserLanguage.cookieKey` a lo que desee, el valor predeterminado es _i18n_redirected_.
 

--- a/docs/es/options-reference.md
+++ b/docs/es/options-reference.md
@@ -44,7 +44,7 @@ Aquí están todas las opciones disponibles al configurar el módulo y sus valor
   // - 'prefix_and_default': add locale prefix for every locale and default
   strategy: 'prefix_except_default',
 
-  // Wether or not the translations should be lazy-loaded, if this is enabled,
+  // Whether or not the translations should be lazy-loaded, if this is enabled,
   // you MUST configure langDir option, and locales must be an array of objects,
   // each containing a file key
   lazy: false,
@@ -61,9 +61,10 @@ Aquí están todas las opciones disponibles al configurar el módulo y sus valor
   // }
   rootRedirect: null,
 
-  // Enable browser language detection to automatically redirect user
-  // to their preferred language as they visit your app for the first time
-  // Set to false to disable
+  // Enable browser language detection to automatically redirect visitors to their
+  // preferred language as they visit your site for the first time.
+  // Note that for better SEO it's recommended to set 'detectOnlyOnRoot' to true.
+  // Set to false to disable.
   detectBrowserLanguage: {
     // If enabled, a cookie is set once a user has been redirected to his
     // preferred language to prevent subsequent redirections
@@ -76,7 +77,11 @@ Aquí están todas las opciones disponibles al configurar el módulo y sus valor
     // Set to always redirect to value stored in the cookie, not just once
     alwaysRedirect: false,
     // If no locale for the browsers locale is a match, use this one as a fallback
-    fallbackLocale: null
+    fallbackLocale: null,
+    // Set to true (recommended for improved SEO) to only attempt to detect browser language when
+    // visiting root path of the site.
+    // Only effective when 'alwaysRedirect' is 'false' and using strategy other than 'no_prefix'.
+    detectOnlyOnRoot: false,
   },
 
   // Set this to true if you're using different domains for each language

--- a/docs/options-reference.md
+++ b/docs/options-reference.md
@@ -57,7 +57,7 @@ Here are all the options available when configuring the module and their default
   // - 'prefix_and_default': add locale prefix for every locale and default
   strategy: 'prefix_except_default',
 
-  // Wether or not the translations should be lazy-loaded, if this is enabled,
+  // Whether or not the translations should be lazy-loaded, if this is enabled,
   // you MUST configure langDir option, and locales must be an array of objects,
   // each containing a file key
   lazy: false,
@@ -74,9 +74,10 @@ Here are all the options available when configuring the module and their default
   // }
   rootRedirect: null,
 
-  // Enable browser language detection to automatically redirect user
-  // to their preferred language as they visit your app for the first time
-  // Set to false to disable
+  // Enable browser language detection to automatically redirect visitors to their
+  // preferred language as they visit your site for the first time.
+  // Note that for better SEO it's recommended to set 'detectOnlyOnRoot' to true.
+  // Set to false to disable.
   detectBrowserLanguage: {
     // If enabled, a cookie is set once a user has been redirected to his
     // preferred language to prevent subsequent redirections
@@ -89,7 +90,11 @@ Here are all the options available when configuring the module and their default
     // Set to always redirect to value stored in the cookie, not just once
     alwaysRedirect: false,
     // If no locale for the browsers locale is a match, use this one as a fallback
-    fallbackLocale: null
+    fallbackLocale: null,
+    // Set to true (recommended for improved SEO) to only attempt to detect browser language when
+    // visiting root path of the site.
+    // Only effective when 'alwaysRedirect' is 'false' and using strategy other than 'no_prefix'.
+    detectOnlyOnRoot: false,
   },
 
   // Set this to true if you're using different domains for each language

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -35,6 +35,7 @@ exports.DEFAULT_OPTIONS = {
     cookieDomain: null,
     cookieKey: 'i18n_redirected',
     alwaysRedirect: false,
+    detectOnlyOnRoot: false,
     fallbackLocale: ''
   },
   differentDomains: false,

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -150,7 +150,7 @@ export default async (context) => {
     app.i18n.__baseUrl = resolveBaseUrl(baseUrl, context)
 
     const finalLocale =
-      (detectBrowserLanguage && doDetectBrowserLanguage()) ||
+      (detectBrowserLanguage && doDetectBrowserLanguage(route)) ||
       getLocaleFromRoute(route) || app.i18n.locale || app.i18n.defaultLocale || ''
 
     await app.i18n.setLocale(finalLocale)
@@ -158,13 +158,17 @@ export default async (context) => {
     return [null, null]
   }
 
-  const doDetectBrowserLanguage = () => {
+  const doDetectBrowserLanguage = route => {
     // Browser detection is ignored if it is a nuxt generate.
     if (process.static && process.server) {
       return false
     }
 
-    const { alwaysRedirect, fallbackLocale } = detectBrowserLanguage
+    const { alwaysRedirect, detectOnlyOnRoot, fallbackLocale } = detectBrowserLanguage
+
+    if (!alwaysRedirect && strategy !== STRATEGIES.NO_PREFIX && detectOnlyOnRoot && route.path !== '/') {
+      return false
+    }
 
     let matchedLocale
 
@@ -228,7 +232,7 @@ export default async (context) => {
     }
   }
 
-  let finalLocale = detectBrowserLanguage && doDetectBrowserLanguage()
+  let finalLocale = detectBrowserLanguage && doDetectBrowserLanguage(route)
 
   if (!finalLocale) {
     if (vuex && vuex.syncLocale && store && store.state[vuex.moduleName].locale !== '') {

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -1012,6 +1012,34 @@ describe('with router base', () => {
     const newRoute = window.$nuxt.localePath('about')
     expect(newRoute).toBe('/about-us')
   })
+
+  test('detectBrowserLanguage redirects on base path', async () => {
+    const requestOptions = {
+      followRedirect: false,
+      resolveWithFullResponse: true,
+      simple: false, // Don't reject on non-2xx response
+      headers: {
+        'Accept-Language': 'fr'
+      }
+    }
+    const response = await get('/app/', requestOptions)
+    expect(response.statusCode).toBe(302)
+    expect(response.headers.location).toBe('/app/fr')
+  })
+
+  test('detectBrowserLanguage redirects on non-base path', async () => {
+    const requestOptions = {
+      followRedirect: false,
+      resolveWithFullResponse: true,
+      simple: false, // Don't reject on non-2xx response
+      headers: {
+        'Accept-Language': 'fr'
+      }
+    }
+    const response = await get('/app/simple', requestOptions)
+    expect(response.statusCode).toBe(302)
+    expect(response.headers.location).toBe('/app/fr/simple')
+  })
 })
 
 describe('baseUrl', () => {
@@ -1340,6 +1368,17 @@ describe('no_prefix + detectBrowserLanguage + alwaysRedirect', () => {
     const html = await get('/', requestOptions)
     const dom = getDom(html)
     expect(dom.querySelector('#current-locale')?.textContent).toBe('locale: en')
+  })
+
+  test('applies detected locale on non-root path', async () => {
+    const requestOptions = {
+      headers: {
+        'Accept-Language': 'fr'
+      }
+    }
+    const html = await get('/about', requestOptions)
+    const dom = getDom(html)
+    expect(dom.querySelector('#current-page')?.textContent).toBe('page: À propos')
   })
 })
 

--- a/types/nuxt-i18n.d.ts
+++ b/types/nuxt-i18n.d.ts
@@ -32,6 +32,7 @@ declare namespace NuxtVueI18n {
       cookieDomain?: string | null
       cookieKey?: string
       alwaysRedirect?: boolean
+      detectOnlyOnRoot?: boolean
       fallbackLocale?: Locale | null
     }
 


### PR DESCRIPTION
Don't attempt to detect browser's language when user (or crawler) goes
directly to a page with a locale prefix. This is to avoid redirecting
user that potentially wanted to load that specific page rather than the
one matching browser's language.
